### PR TITLE
Interface Emailing

### DIFF
--- a/Data/Emailing.js
+++ b/Data/Emailing.js
@@ -6,6 +6,7 @@ const Logger = require("./../Logging/Logger.js")
 const ID = require("./../Data/ID.js")
 
 const sendmail = require("./../Interfacing/SendMail.js")
+const smtpmail = require("./../Interfacing/SMTPMail.js")
 
 let baseURL
 let domain
@@ -22,13 +23,17 @@ exports.init = function (ServerConfig){
     domain = new URL(baseURL).hostname
     Logger.Log("Initialized Mailing!")
     switch (ServerConfig.LoadedConfig.EmailInterface.toLowerCase()){
-        case "ses":
-            // TODO: SES Interface
+        case "smtp":
+            emailInterface = smtpmail
             break
         default:
-            emailInterface = sendmail.create()
+            emailInterface = sendmail
             break
     }
+    emailInterface = emailInterface.create(ServerConfig.LoadedConfig)
+    let overrideDomain = emailInterface.getDomain()
+    if(overrideDomain !== undefined)
+        domain = overrideDomain
 }
 
 exports.isValidEmail = function (email) {

--- a/Data/ServerConfig.js
+++ b/Data/ServerConfig.js
@@ -57,6 +57,7 @@ exports.LoadedConfig = {
         Server: "",
         Port: 465,
         Secure: true,
+        NoTLS: false,
         Username: "",
         Password: "",
         OverrideDomain: ""

--- a/Data/ServerConfig.js
+++ b/Data/ServerConfig.js
@@ -53,14 +53,19 @@ exports.LoadedConfig = {
         clamdHealthCheckInterval: null
     },
     EmailInterface: "sendmail",
-    SESSettings:{
-        region: "nyc3"
+    SMTPSettings:{
+        Server: "",
+        Port: 465,
+        Secure: true,
+        Username: "",
+        Password: "",
+        OverrideDomain: ""
     },
     GameServerTokens: [],
     AllowAnyGameServer: false,
     RequireTokenToDownloadBuilds: false,
     GameEngine: "Unity",
-    GameEngineVersion: "2022.3.5f1"
+    GameEngineVersion: "2023.2.20f1"
 }
 
 exports.init = function (){

--- a/Data/ServerConfig.js
+++ b/Data/ServerConfig.js
@@ -52,6 +52,10 @@ exports.LoadedConfig = {
         clamdTimeout: null,
         clamdHealthCheckInterval: null
     },
+    EmailInterface: "sendmail",
+    SESSettings:{
+        region: "nyc3"
+    },
     GameServerTokens: [],
     AllowAnyGameServer: false,
     RequireTokenToDownloadBuilds: false,

--- a/Interfacing/SMTPMail.js
+++ b/Interfacing/SMTPMail.js
@@ -1,0 +1,43 @@
+const nodemailer = require("nodemailer")
+
+let ServerConfig
+
+exports.create = function (config){
+    ServerConfig = config
+    return this;
+}
+
+exports.getDomain = function () {
+    if(ServerConfig.SMTPSettings.OverrideDomain === undefined || ServerConfig.SMTPSettings.OverrideDomain === "")
+        return undefined
+    return ServerConfig.SMTPSettings.OverrideDomain
+}
+
+exports.sendEmail = function (data) {
+    return new Promise((exec, reject) => {
+        const transporter = nodemailer.createTransport({
+            host: ServerConfig.SMTPSettings.Server,
+            port: ServerConfig.SMTPSettings.Port,
+            secure: ServerConfig.SMTPSettings.Secure,
+            auth: {
+                user: ServerConfig.SMTPSettings.Username,
+                pass: ServerConfig.SMTPSettings.Password,
+            },
+            tls: {
+                ciphers: "SSLv3"
+            }
+        })
+        const mailOptions = {
+            from: data.from,
+            to: data.to,
+            subject: data.subject,
+            html: data.html
+        }
+        transporter.sendMail(mailOptions, err => {
+            if(err)
+                reject(err)
+            else
+                exec(true)
+        })
+    })
+}

--- a/Interfacing/SMTPMail.js
+++ b/Interfacing/SMTPMail.js
@@ -15,18 +15,18 @@ exports.getDomain = function () {
 
 exports.sendEmail = function (data) {
     return new Promise((exec, reject) => {
-        const transporter = nodemailer.createTransport({
+        let connectionInfo = {
             host: ServerConfig.SMTPSettings.Server,
             port: ServerConfig.SMTPSettings.Port,
             secure: ServerConfig.SMTPSettings.Secure,
             auth: {
                 user: ServerConfig.SMTPSettings.Username,
                 pass: ServerConfig.SMTPSettings.Password,
-            },
-            tls: {
-                ciphers: "SSLv3"
             }
-        })
+        }
+        if(!ServerConfig.SMTPSettings.NoTLS)
+            connectionInfo.tls = { ciphers: "SSLv3" }
+        const transporter = nodemailer.createTransport(connectionInfo)
         const mailOptions = {
             from: data.from,
             to: data.to,

--- a/Interfacing/SendMail.js
+++ b/Interfacing/SendMail.js
@@ -1,0 +1,19 @@
+const nodemailer = require("nodemailer")
+
+exports.create = function (){return this;}
+
+exports.sendEmail = function (data) {
+    return new Promise((exec, reject) => {
+        const transporter = nodemailer.createTransport({sendmail: true}, {
+            from: data.from,
+            to: data.to,
+            subject: data.subject,
+        })
+        transporter.sendMail({html: data.html}, err => {
+            if(err)
+                reject(err)
+            else
+                exec(true)
+        })
+    })
+}

--- a/Interfacing/SendMail.js
+++ b/Interfacing/SendMail.js
@@ -1,6 +1,8 @@
 const nodemailer = require("nodemailer")
 
-exports.create = function (){return this;}
+exports.create = function (config){return this;}
+
+exports.getDomain = function () {return undefined}
 
 exports.sendEmail = function (data) {
     return new Promise((exec, reject) => {

--- a/main.js
+++ b/main.js
@@ -36,6 +36,8 @@ if(ServerConfig.LoadedConfig.TrustAllDomains)
     Logger.Warning("TrustAllDomains is enabled, this should not be done for production!")
 if(ServerConfig.LoadedConfig.AllowAnyGameServer)
     Logger.Warning("AllowAnyGameServer is enabled! Any server can pose as a game server, this may be dangerous!")
+if(ServerConfig.LoadedConfig.EmailInterface.toLowerCase() === "smtp" && !ServerConfig.LoadedConfig.SMTPSettings.Secure)
+    Logger.Warning("SMTP Security is disabled, this should not be done for production!")
 
 // Database
 let databaseUsername


### PR DESCRIPTION
This PR adds support for interfacing email clients, allowing servers to implement their own emailing system.

## Why?

The biggest reason as to why, is during my research, there are millions of ways to reliably send emails, and millions more ways to do it with varying pricing, and a billion ways to do it completely incorrectly. Being an open-source project, this makes it incredibly difficult to pick just one method, so we won't! We will leave up the solution to each host. For some people, maybe a free sandbox plan is suitable, or for someone else, they could go more advanced with a large-scale service. This PR leaves room for that.

## How is this accomplished?

Our current implementation has two services.

1. **Sendmail**
    - This is our previous service which is essentially mailing self-hosted. It's great for small projects and custom emails, but doesn't hold up well with bigger services like gmail, icloud, etc.
2. **SMTP**
    - A custom SMTP server. Simply fill your SMTP information in the console and you're on your way! This makes implementing many services easy and doable.

And there is plenty of room to add specific support for certain services. Simply add a js file with the three methods

```js
create(ServerConfig){return this}
getDomain(){return String}
sendMail(data){}
```

...then reference it in Emailing.js