### PR TITLE
Rework Instance Endpoints

### DIFF
--- a/API/Server.js
+++ b/API/Server.js
@@ -1221,14 +1221,15 @@ exports.initapp = function (usersModule, socketServerModule, serverConfig, cdns,
     })
 
     app.post(getAPIEndpoint() + "instances", function (req, res) {
+        let worldid = req.body.worldid
         let userid = req.body.userid
         let tokenContent = req.body.tokenContent
-        if(isUserBodyValid(userid, "string") && isUserBodyValid(tokenContent, "string")){
+        if(isUserBodyValid(worldid, "string") && isUserBodyValid(userid, "string") && isUserBodyValid(tokenContent, "string")){
             Users.isUserIdTokenValid(userid, tokenContent).then(isTokenValid => {
                 if(isTokenValid){
                     Users.getUserDataFromUserId(userid).then(user => {
                         if(user !== undefined){
-                            SocketServer.GetSafeInstances(user).then(instances => {
+                            SocketServer.GetSafeInstances(user, worldid).then(instances => {
                                 if(instances !== undefined){
                                     res.end(APIMessage.craftAPIMessage(true, "Got instances!", {
                                         SafeInstances: instances

--- a/API/SocketServer.js
+++ b/API/SocketServer.js
@@ -852,14 +852,13 @@ exports.IsUserInInstance = function (userId){
     return v
 }
 
-exports.GetSafeInstances = function (user) {
-    return new Promise(exec => {
-        let instanceLoops = 0
+exports.GetSafeInstances = function (user, worldid) {
+    return new Promise(async exec => {
         let is = []
         let l = Instances.length
-        let instanceClones = ArrayTools.clone(Instances)
         for(let i = 0; i < l; i++){
-            let instance = instanceClones[i]
+            let instance = Instances[i]
+            if(instance.WorldId !== worldid) continue
             let safeinstance = {
                 GameServerId: instance.GameServerId,
                 InstanceId: instance.InstanceId,
@@ -869,19 +868,11 @@ exports.GetSafeInstances = function (user) {
                 ConnectedUsers: instance.ConnectedUsers,
                 WorldId: instance.WorldId
             }
-            isUserWelcomeInInstance(instance, user.Id).then(b => {
-                if(b)
-                    is.push(safeinstance)
-                instanceLoops++
-            }).catch(() => instanceLoops++)
+            let b = await isUserWelcomeInInstance(instance, user.Id)
+            if(b)
+                is.push(safeinstance)
         }
-        // TODO: This could *probably* be better
-        let interval = setInterval(() => {
-            if(instanceLoops >= l){
-                exec(is)
-                clearInterval(interval)
-            }
-        }, 10)
+        exec(is)
     })
 }
 


### PR DESCRIPTION
In this PR, this changes how instances are collected for users. Specifically, all instance callbacks are linked to a WorldId, where there are two separate endpoints.

+ GET `/api/v1/instances/:worldid`
  + Gets all public instances of a world
+ POST `/api/v1/instances`
  + Gets all public and private instances of a world
  + Based on the current user

As for the POST link, the body would look like the following

```json
{
    "worldid": "worldid_xxxx",
    "userid": "user_xxxx",
    "tokenContent": "token"
}
```

This also includes improvements for how instances are pulled. The memory consumed should be less, and intervals are no longer used to check safe instances.